### PR TITLE
Add option to prevent caching of empty values

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Rails.application.routes.draw do
 end
 ```
 
+## Caching empty values ##
+By default, copycat will cache empty values in the database. If a lookup results to a missing translation a new copycat entry will be created with an empty value for this locale and key.
+This may not be desirable, especially during development, as after the first lookup copycat will always serve the empty translation, preventing the YML files from being consulted again for this locale and key.
+Changing the default behaviour can be achieved through the following setting on the initializer:
+
+```ruby
+config.create_nils = false
+```
+
 ## Logging ##
 Because Copycat does a SQL query for each token, it can produce a lot of noise in the log output.
 Therefore by default the logger is disabled for the Copycat ActiveRecord class.

--- a/lib/copycat.rb
+++ b/lib/copycat.rb
@@ -7,7 +7,9 @@ module Copycat
   mattr_accessor :username
   mattr_accessor :password
   mattr_accessor :route
+  mattr_accessor :create_nils
   @@route = 'copycat_translations'
+  @@create_nils = true
 
   def self.setup
     yield self

--- a/lib/copycat/implementation.rb
+++ b/lib/copycat/implementation.rb
@@ -6,7 +6,7 @@ module Copycat
       cct = CopycatTranslation.where(locale: locale.to_s, key: key.to_s).first
       return cct.value if cct
       value = super(locale, key, scope, options)
-      if value.is_a?(String) || value.nil?
+      if value.is_a?(String) || value.nil? && Copycat.create_nils
         CopycatTranslation.create(locale: locale.to_s, key: key.to_s, value: value)
       end
       value

--- a/lib/tasks/copycat_tasks.rake
+++ b/lib/tasks/copycat_tasks.rake
@@ -15,6 +15,7 @@ namespace :copycat do
 Copycat.setup do |config|
   config.username = '#{username}'
   config.password = '#{password}'
+  #config.create_nils = true
   #config.route = 'copycat_translations'
 end
 CONFIG

--- a/spec/integration/dummy_spec.rb
+++ b/spec/integration/dummy_spec.rb
@@ -21,10 +21,18 @@ feature "use #t" do
     CopycatTranslation.find_by_key('site.index.header').should_not be_nil
   end
 
-  it "creates a copycat_translation if the yaml does not have an entry" do
+  it "by default creates an empty copycat_translation if the yaml does not have an entry" do
+    Copycat.create_nils = true
     CopycatTranslation.find_by_key('site.index.intro').should be_nil
     visit root_path
     CopycatTranslation.find_by_key('site.index.intro').should_not be_nil
+  end
+
+  it "does not create an empty copycat_translation when create_nils is set to false" do
+    Copycat.create_nils = false
+    CopycatTranslation.find_by_key('site.index.intro').should be_nil
+    visit root_path
+    CopycatTranslation.find_by_key('site.index.intro').should be_nil
   end
 
   it "shows the copycat_translation instead of the yaml" do


### PR DESCRIPTION
Added configuration option to turn off creation of empty copycat entries when no translation is found. Should fix #15
